### PR TITLE
Fix for import files not triggering compilation

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -153,7 +153,7 @@ class Wp_Scss {
       $latest_scss = 0;
       $latest_css = 0;
 
-      foreach ( new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->scss_dir), FilesystemIterator::SKIP_DOTS) as $sfile ) {
+      foreach ( new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->scss_dir, RecursiveDirectoryIterator::SKIP_DOTS)) as $sfile ) {
         if (pathinfo($sfile->getFilename(), PATHINFO_EXTENSION) == 'scss') {
           $file_time = $sfile->getMTime();
 
@@ -163,7 +163,7 @@ class Wp_Scss {
         }
       }
 
-      foreach ( new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->css_dir), FilesystemIterator::SKIP_DOTS) as $cfile ) {
+      foreach ( new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->css_dir, RecursiveDirectoryIterator::SKIP_DOTS)) as $cfile ) {
         if (pathinfo($cfile->getFilename(), PATHINFO_EXTENSION) == 'css') {
           $file_time = $cfile->getMTime();
 


### PR DESCRIPTION
Imported files were not triggering auto-compilation on page load, because the previous fix was using the wrong class to skip dots. This update fixes this issue and hopefully with a new roll out of the plugin, will fix everyone else's.